### PR TITLE
This fixes the bug that was causing tests to fail

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,6 @@ const buildTable = require('./buildTable');
 const initialRoots = buildTable(global);
 console.log('initialRoots are', initialRoots);
 
-const harden = makeHardener(initialRoots);
+const harden = makeHardener(...initialRoots);
 
 module.exports = { harden };


### PR DESCRIPTION
We had an issue where tests were failing because makeHardener used rest syntax, so our Set of initialRoots was getting wrapped in an array. We can deal with this a couple of ways, either removing the rest syntax and only passing in iterables, or by using spread syntax. This PR went with the second because it seemed better for the user to not have to wrap their objects in arrays. 