### PR TITLE
change export - fixes #8

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,4 +23,4 @@ console.log('initialRoots are', initialRoots);
 
 const harden = makeHardener(...initialRoots);
 
-module.exports = { harden };
+module.exports = harden;

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 /* eslint no-undef: "off" */
 
 const test = require('tape');
-const { harden } = require('../src/index.js');
+const harden = require('../src/index.js');
 
 test('harden', t => {
   const o = { a: {} };


### PR DESCRIPTION
This changes the export to directly export harden. Fixes Issue #8 

## Considerations
This is a breaking change. Ordinarily we'd want to bump the version, but I think we are still in early enough stages that we don't need to until republishing.