### PR TITLE
add anonIntrinsics to the fringe

### DIFF
--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -40,6 +40,8 @@ Rollup is a little trickier. If we try to use rollup to bundle the tests and har
 
 Parcel uses the ES6 module version of the test that we created and creates a new index.html and JavaScript files in `bundles/parcel`.
 
+Parcel uses babel to transpile the code into a "least-common-denominator" form which avoids features that aren't universally available in all browsers. Its definition of "universal" defaults to 99.75%, which unfortunately excludes generators (and we don't include the plugin that would be necessary to allows its polyfill to work). We reduce this setting to 50% for the integration test. Downstream applications which use Parcel would set this according to local taste, and would include whatever plugins are necessary to let the polyfills work.
+
 ### Unpkg
 
 Unpkg isn't really a bundler at all, but is a CDN. We create a browser-friendly version of the tape tests and load both the tests and a mocked version of the library provided by unpkg together on the same page to run the tests. 

--- a/integration-test/package.json
+++ b/integration-test/package.json
@@ -17,6 +17,9 @@
     "build:rollup": "rollup -c scaffolding/rollup/rollup.config.test.js",
     "build:parcel": "parcel build scaffolding/parcel/index.html --public-url ./ -d bundles/parcel"
   },
+  "browserslist": [
+    "cover 50%"
+  ],
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/integration-test/test/utility/test-bundler.js
+++ b/integration-test/test/utility/test-bundler.js
@@ -36,7 +36,7 @@ const runBrowserTests = async indexFile => {
 const testBundler = (bundlerName, indexFile) => {
   test(`harden works with ${bundlerName}`, t => {
     runBrowserTests(indexFile).then(({ numTests, numPass }) => {
-      t.equal(numTests, '3');
+      t.equal(numTests, '26');
       t.equal(numTests, numPass);
       t.end();
     });

--- a/src/buildTable.js
+++ b/src/buildTable.js
@@ -16,6 +16,8 @@
 import getAnonIntrinsics from './anonIntrinsics';
 import whitelist from './whitelist';
 
+const { create, getOwnPropertyDescriptors } = Object;
+
 export default function buildTable(global) {
   // walk global object, add whitelisted properties to table
 
@@ -135,7 +137,7 @@ export default function buildTable(global) {
   // To avoid including the global itself in this set, we make a new object
   // that has all the same properties. In SES, we'll freeze the global
   // separately.
-  const globals = Object.create(null, Object.getOwnPropertyDescriptors(global));
+  const globals = create(null, getOwnPropertyDescriptors(global));
   addToWhiteTable(globals, whitelist.namedIntrinsics);
   const intrinsics = getAnonIntrinsics(global);
   addToWhiteTable(intrinsics, whitelist.anonIntrinsics);

--- a/src/buildTable.js
+++ b/src/buildTable.js
@@ -16,7 +16,7 @@
 import getAnonIntrinsics from './anonIntrinsics';
 import whitelist from './whitelist';
 
-function buildTable(global) {
+export default function buildTable(global) {
   // walk global object, add whitelisted properties to table
 
   const uncurryThis = fn => (thisArg, ...args) =>
@@ -103,21 +103,21 @@ function buildTable(global) {
     }
   }
 
-  const table = new Set();
+  const fringeTable = new Set();
   /**
    * Walk the table, adding everything that's on the whitelist to a Set for
      later use.
    *
    */
-  function add(value, prefix) {
+  function addToFringeTable(value, prefix) {
     if (value !== Object(value)) {
       return;
     }
-    if (table.has(value)) {
+    if (fringeTable.has(value)) {
       return;
     }
 
-    table.add(value);
+    fringeTable.add(value);
     gopn(value).forEach(name => {
       const path = prefix + (prefix ? '.' : '') + name;
       const p = getPermit(value, name);
@@ -126,17 +126,29 @@ function buildTable(global) {
         if (hop(desc, 'value')) {
           // Is a data property
           const subValue = desc.value;
-          add(subValue, path);
+          addToFringeTable(subValue, path);
         }
       }
     });
   }
 
-  addToWhiteTable(global, whitelist.namedIntrinsics);
-  const intr = getAnonIntrinsics(global);
-  addToWhiteTable(intr, whitelist.anonIntrinsics);
-  add(global, '');
-  return table;
-}
+  // To avoid including the global itself in this set, we make a new object
+  // that has all the same properties. In SES, we'll freeze the global
+  // separately.
+  const globals = Object.create(null, Object.getOwnPropertyDescriptors(global));
+  addToWhiteTable(globals, whitelist.namedIntrinsics);
+  const intrinsics = getAnonIntrinsics(global);
+  addToWhiteTable(intrinsics, whitelist.anonIntrinsics);
+  // whiteTable is now a map from objects to a 'permit'
 
-export default buildTable;
+  // getPermit() is a non-recursive function taking (obj, propname) and
+  // returning a permit
+
+  // addToFringeTable() does a recursive property walk of its first argument,
+  // finds everything that getPermit() allows, and puts them all into the Set
+  // named 'fringeTable'
+
+  addToFringeTable(globals, '');
+  addToFringeTable(intrinsics, '');
+  return fringeTable;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -52,3 +52,17 @@ test('harden overlapping objects', t => {
   t.ok(Object.isFrozen(o2));
   t.end();
 });
+
+test('harden function', t => {
+  const o = _a => 1;
+  t.equal(harden(o), o);
+  t.ok(Object.isFrozen(o));
+  t.end();
+});
+
+test('harden async function', t => {
+  const o = async _a => 1;
+  t.equal(harden(o), o);
+  t.ok(Object.isFrozen(o));
+  t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -66,3 +66,23 @@ test('harden async function', t => {
   t.ok(Object.isFrozen(o));
   t.end();
 });
+
+test('harden generator', t => {
+  function* o() {
+    yield 1;
+    yield 2;
+  }
+  t.equal(harden(o), o);
+  t.ok(Object.isFrozen(o));
+  t.end();
+});
+
+test('harden async generator', t => {
+  async function* o() {
+    yield 1;
+    yield 2;
+  }
+  t.equal(harden(o), o);
+  t.ok(Object.isFrozen(o));
+  t.end();
+});

--- a/test/test.js
+++ b/test/test.js
@@ -11,27 +11,11 @@ test('harden', t => {
   t.end();
 });
 
-test.skip('do not freeze roots', t => {
+test('complain about prototype not in roots', t => {
   const parent = { I_AM_YOUR: 'parent' };
-  const h = makeHardener(parent, Object.prototype);
   const o = { a: {} };
   Object.setPrototypeOf(o, parent);
-  t.equal(h(o), o);
-  t.ok(Object.isFrozen(o));
-  t.ok(Object.isFrozen(o.a));
-  t.notOk(Object.isFrozen(parent));
-  t.end();
-});
-
-test.skip('complain about prototype not in roots', t => {
-  const parent = { I_AM_YOUR: 'parent' };
-  // at least one prototype is missing in each hardener
-  const h1 = makeHardener(Object.prototype);
-  const h2 = makeHardener(parent);
-  const o = { a: {} };
-  Object.setPrototypeOf(o, parent);
-  t.throws(() => h1(o), TypeError);
-  t.throws(() => h2(o), TypeError);
+  t.throws(() => harden(o), TypeError);
   // if harden() throws TypeError, we make no claims about what properties
   // got frozen. However, we know for sure that the prototype shouldn't be
   // frozen: this is what saves us from the "ice-9" freeze-the-world scenario
@@ -39,35 +23,32 @@ test.skip('complain about prototype not in roots', t => {
   t.end();
 });
 
-test.skip('harden the same thing twice', t => {
-  const h = makeHardener(Object.prototype);
+test('harden the same thing twice', t => {
   const o = { a: {} };
-  t.equal(h(o), o);
-  t.equal(h(o), o);
+  t.equal(harden(o), o);
+  t.equal(harden(o), o);
   t.ok(Object.isFrozen(o));
   t.ok(Object.isFrozen(o.a));
   t.end();
 });
 
-test.skip('harden objects with cycles', t => {
-  const h = makeHardener(Object.prototype);
+test('harden objects with cycles', t => {
   const o = { a: {} };
   o.a.foo = o;
-  t.equal(h(o), o);
+  t.equal(harden(o), o);
   t.ok(Object.isFrozen(o));
   t.ok(Object.isFrozen(o.a));
   t.end();
 });
 
-test.skip('harden overlapping objects', t => {
-  const h = makeHardener(Object.prototype);
+test('harden overlapping objects', t => {
   const o1 = { a: {} };
   const o2 = { a: o1.a };
-  t.equal(h(o1), o1);
+  t.equal(harden(o1), o1);
   t.ok(Object.isFrozen(o1));
   t.ok(Object.isFrozen(o1.a));
   t.notOk(Object.isFrozen(o2));
-  t.equal(h(o2), o2);
+  t.equal(harden(o2), o2);
   t.ok(Object.isFrozen(o2));
   t.end();
 });


### PR DESCRIPTION
We were omitting the "anonymous intrinsics" from the fringe, so `harden()` would fail when given async functions, generator functions, async generator functions, generator instances, and async generator instances. Probably some other exotic objects too.

This rewrites the intrinsics management to include all the prototypes to enable freezing those things.
