### PR TITLE
Fix: Delete npm-audit-fix branch in AgoricBot script

### DIFF
--- a/scripts/npm-audit-fix.sh
+++ b/scripts/npm-audit-fix.sh
@@ -33,3 +33,5 @@ if [ "$files_changed" = true ] ; then
   git push origin npm-audit-fix
   hub pull-request --no-edit --base Agoric/harden:master
 fi
+
+git push --delete origin npm-audit-fix


### PR DESCRIPTION
If we don't delete the npm-audit-branch in the AgoricBot fork, we get the following error:

```
 ! [rejected]        npm-audit-fix -> npm-audit-fix (non-fast-forward)
error: failed to push some refs to 'https://AgoricBot:5ec0ab65b348ecd6b96628f9bd3ee1596296611e@github.com/AgoricBot/make-hardener.git'
hint: Updates were rejected because the tip of your current branch is behind
hint: its remote counterpart. Integrate the remote changes (e.g.
hint: 'git pull ...') before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.
Aborted: no commits detected between upstream/master and npm-audit-fix
Exited with code 1
```