### PR TITLE
manual 'npm audit fix' for integration-test

### DIFF
--- a/integration-test/package-lock.json
+++ b/integration-test/package-lock.json
@@ -5717,9 +5717,9 @@
       }
     },
     "mixin-deep": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-      "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+      "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
       "dev": true,
       "requires": {
         "for-in": "^1.0.2",
@@ -7655,9 +7655,9 @@
       "dev": true
     },
     "safer-eval": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/safer-eval/-/safer-eval-1.3.2.tgz",
-      "integrity": "sha512-mAkc9NX+ULPw4qX+lkFVuIhXQbjFaX97fWFj6atFXMG11lUX4rXfQY6Q0VFf1wfJfqCHYO7cxtC7cA8fIkWsLQ==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/safer-eval/-/safer-eval-1.3.5.tgz",
+      "integrity": "sha512-BJ//K2Y+EgCbOHEsDGS5YahYBcYy7JcFpKDo2ba5t4MnOGHYtk7HvQkcxTDFvjQvJ0CRcdas/PyF+gTTCay+3w==",
       "dev": true,
       "requires": {
         "clones": "^1.2.0"
@@ -7759,9 +7759,9 @@
       "dev": true
     },
     "set-value": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-      "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
       "dev": true,
       "requires": {
         "extend-shallow": "^2.0.1",
@@ -8744,38 +8744,15 @@
       }
     },
     "union-value": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-      "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
       "dev": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
         "is-extendable": "^0.1.1",
-        "set-value": "^0.4.3"
-      },
-      "dependencies": {
-        "extend-shallow": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-          "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-          "dev": true,
-          "requires": {
-            "is-extendable": "^0.1.0"
-          }
-        },
-        "set-value": {
-          "version": "0.4.3",
-          "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-          "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.1",
-            "to-object-path": "^0.3.0"
-          }
-        }
+        "set-value": "^2.0.1"
       }
     },
     "uniq": {


### PR DESCRIPTION
This is a manual application of 'npm audit fix', because the CircleCI process failed due to AgoricBot already having a PR open. There were also commands that had to be run manually (see the [CircleCI logs](https://circleci.com/gh/Agoric/harden/385?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification) and below):

```
                       === npm audit security report ===                        
                                                                                
# Run  npm update set-value --depth 11  to resolve 47 vulnerabilities
# Run  npm update mixin-deep --depth 10  to resolve 47 vulnerabilities

found 142 high severity vulnerabilities in 15327 scanned packages
  run `npm audit fix` to fix 142 of them.

> deasync@0.1.14 install /home/circleci/project/harden/integration-test/node_modules/deasync
> node ./build.js

`linux-x64-node-10` exists; testing
Binary is fine; exiting

> puppeteer@1.13.0 install /home/circleci/project/harden/integration-test/node_modules/puppeteer
> node install.js

Downloading Chromium r637110 - 109.4 Mb [] 0% 255.6s Downloading Chromium r637110 - 109.4 Mb [] 0% 3.4s Downloading Chromium r637110 - 109.4 Mb [] 1% 1.7s Downloading Chromium r637110 - 109.4 Mb [] 3% 1.5s Downloading Chromium r637110 - 109.4 Mb [] 4% 1.5s Downloading Chromium r637110 - 109.4 Mb [] 5% 1.5s Downloading Chromium r637110 - 109.4 Mb [] 6% 1.4s Downloading Chromium r637110 - 109.4 Mb [] 11% 0.9s Downloading Chromium r637110 - 109.4 Mb [] 12% 0.9s Downloading Chromium r637110 - 109.4 Mb [] 13% 1.0s Downloading Chromium r637110 - 109.4 Mb [] 14% 1.0s Downloading Chromium r637110 - 109.4 Mb [] 16% 1.0s Downloading Chromium r637110 - 109.4 Mb [] 18% 0.9s Downloading Chromium r637110 - 109.4 Mb [] 21% 0.8s Downloading Chromium r637110 - 109.4 Mb [] 23% 0.8s Downloading Chromium r637110 - 109.4 Mb [] 25% 0.7s Downloading Chromium r637110 - 109.4 Mb [] 29% 0.6s Downloading Chromium r637110 - 109.4 Mb [] 34% 0.5s Downloading Chromium r637110 - 109.4 Mb [] 37% 0.5s Downloading Chromium r637110 - 109.4 Mb [] 39% 0.5s Downloading Chromium r637110 - 109.4 Mb [] 41% 0.5s Downloading Chromium r637110 - 109.4 Mb [] 44% 0.4s Downloading Chromium r637110 - 109.4 Mb [] 47% 0.4s Downloading Chromium r637110 - 109.4 Mb [] 52% 0.3s Downloading Chromium r637110 - 109.4 Mb [] 57% 0.3s Downloading Chromium r637110 - 109.4 Mb [] 61% 0.3s Downloading Chromium r637110 - 109.4 Mb [] 66% 0.2s Downloading Chromium r637110 - 109.4 Mb [] 70% 0.2s Downloading Chromium r637110 - 109.4 Mb [] 73% 0.2s Downloading Chromium r637110 - 109.4 Mb [] 77% 0.1s Downloading Chromium r637110 - 109.4 Mb [] 81% 0.1s Downloading Chromium r637110 - 109.4 Mb [] 85% 0.1s Downloading Chromium r637110 - 109.4 Mb [] 89% 0.1s Downloading Chromium r637110 - 109.4 Mb [] 92% 0.0s Downloading Chromium r637110 - 109.4 Mb [] 96% 0.0s Downloading Chromium r637110 - 109.4 Mb [] 100% 0.0s 
Chromium downloaded to /home/circleci/project/harden/integration-test/node_modules/puppeteer/.local-chromium/linux-637110

> parcel@1.12.3 postinstall /home/circleci/project/harden/integration-test/node_modules/parcel
> node -e "console.log('\u001b[35m\u001b[1mLove Parcel? You can now donate to our open collective:\u001b[22m\u001b[39m\n > \u001b[34mhttps://opencollective.com/parcel/donate\u001b[0m')"

Love Parcel? You can now donate to our open collective:
 > https://opencollective.com/parcel/donate
npm WARN optional SKIPPING OPTIONAL DEPENDENCY: fsevents@1.2.7 (node_modules/fsevents):
npm WARN notsup SKIPPING OPTIONAL DEPENDENCY: Unsupported platform for fsevents@1.2.7: wanted {"os":"darwin","arch":"any"} (current: {"os":"linux","arch":"x64"})

added 945 packages from 613 contributors in 15.224s
fixed 142 of 142 vulnerabilities in 15327 scanned packages
[npm-audit-fix ede0483] results of running npm audit fix
 1 file changed, 13 insertions(+), 36 deletions(-)
Counting objects: 4, done.
Delta compression using up to 36 threads.
Compressing objects: 100% (1/1), done.
Writing objects: 100% (4/4), 837 bytes | 0 bytes/s, done.
Total 4 (delta 3), reused 3 (delta 3)
remote: Resolving deltas: 100% (3/3), completed with 3 local objects.        
remote: 
remote: Create a pull request for 'npm-audit-fix' on GitHub by visiting:        
remote:      https://github.com/AgoricBot/harden/pull/new/npm-audit-fix        
remote: 
To https://github.com/AgoricBot/harden.git
 * [new branch]      npm-audit-fix -> npm-audit-fix
Error creating pull request: Unprocessable Entity (HTTP 422)
A pull request already exists for AgoricBot:npm-audit-fix.
Exited with code 1
```

